### PR TITLE
Fix fill example variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Assert::that(sizeof($records) > 0);
 ```php
 public function fill(array $values): array
 {
-    Assert::that(sizeof($value) > 0);
+    Assert::that(sizeof($values) > 0);
     Assert::that(sizeof($values) === sizeof(array_filter($values, fn ($value) => is_int($value))));
 
     // logic can now perform on an array with values of integers


### PR DESCRIPTION
## Summary
- correct variable in `fill()` example

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68482f6ee5d48331b23b98244fc9535d