### PR TITLE
Fix misnamed failure test

### DIFF
--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -64,7 +64,7 @@ final class AssertTest extends TestCase
     }
 
     #[DataProvider('provideFalseData')]
-    public function isIsTrueOnFailure(bool $data): void
+    public function testIsTrueOnFailure(bool $data): void
     {
         $this->expectException(AssertionException::class);
         $this->expectExceptionMessage('$value does not meet assertion');


### PR DESCRIPTION
## Summary
- rename misnamed test method

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_b_68482ebee39483319ff1d9b7e5f831d1