### PR TITLE
Drop PHP 8.2 and add 8.3/8.4 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,12 +13,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.3', '8.4']
 
     steps:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: ${{ matrix.php-version }}
         ini-values: error_reporting=E_ALL
         coverage: none
 

--- a/.justfile
+++ b/.justfile
@@ -2,8 +2,8 @@
 set shell := ["bash", "-c"]
 
 drun := "docker run -it -w /data -v ${PWD}:/data:delegated"
-drun-base := "docker run -it -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:8.2-base"
-drun-cli := "docker run -it -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:8.2-cli"
+drun-base := "docker run -it -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:8.4-base"
+drun-cli := "docker run -it -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:8.4-cli"
 
 _default:
   @just --choose
@@ -25,7 +25,7 @@ phpunit *args:
 
 # Run phpunit with coverage
 phpunit-coverage *args:
-    {{drun}} -e XDEBUG_MODE=coverage --rm registry.gitlab.com/grahamcampbell/php:8.2 vendor/bin/phpunit --coverage-html cov {{args}}
+    {{drun}} -e XDEBUG_MODE=coverage --rm registry.gitlab.com/grahamcampbell/php:8.4 vendor/bin/phpunit --coverage-html cov {{args}}
 
 test:
     just phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "vlucas/phpdotenv": "^5.6"
     }
 }


### PR DESCRIPTION
## Summary
- require PHP 8.3+ in composer.json
- test against PHP 8.3 and 8.4 in CI
- update justfile docker image tags to 8.4

## Testing
- `composer validate --strict`
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_b_684842f5509483318ac38dabfce29919