### PR TITLE
Set version 1.0.0 and add tag based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,5 @@
   "require": {
     "php": "^8.3",
     "vlucas/phpdotenv": "^5.6"
-  },
-  "version": "1.0.0"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,39 @@
 {
-    "name": "jlaswell/assert-php",
-    "description": "Simple assertion library",
-    "keywords": ["assertion", "assert", "testing", "test", "John Laswell", "jlaswell"],
-    "type": "library",
-    "require-dev": {
-        "phpunit/phpunit": "^11.4",
-        "psalm/phar": "^5.26"
-    },
-    "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "Jlaswell\\Assert\\": "src/"
-        }
-        
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Jlaswell\\Tests\\Assert\\": "tests/"
-        }
-    },
-    "authors": [
-        {
-            "name": "John Laswell",
-            "email": "john.n.laswell@gmail.com"
-        }
-    ],
-    "require": {
-        "php": "^8.3",
-        "vlucas/phpdotenv": "^5.6"
+  "name": "jlaswell/assert-php",
+  "description": "Simple assertion library",
+  "keywords": [
+    "assertion",
+    "assert",
+    "testing",
+    "test",
+    "John Laswell",
+    "jlaswell"
+  ],
+  "type": "library",
+  "require-dev": {
+    "phpunit/phpunit": "^11.4",
+    "psalm/phar": "^5.26"
+  },
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Jlaswell\\Assert\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Jlaswell\\Tests\\Assert\\": "tests/"
+    }
+  },
+  "authors": [
+    {
+      "name": "John Laswell",
+      "email": "john.n.laswell@gmail.com"
+    }
+  ],
+  "require": {
+    "php": "^8.3",
+    "vlucas/phpdotenv": "^5.6"
+  },
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- declare v1.0.0 in composer.json
- add GitHub Actions workflow for publishing a release when tags are pushed

Local tags `v1.0.0` and `v1.0.1` have been created on this commit.

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6848483ae49c83319adf39030dae05b5